### PR TITLE
Fixing an error where a user doesn't have access to a configured explore

### DIFF
--- a/explore-assistant-extension/src/hooks/useLookerFields.ts
+++ b/explore-assistant-extension/src/hooks/useLookerFields.ts
@@ -1,4 +1,6 @@
+import { ExtensionContext } from '@looker/extension-sdk-react'
 import { useContext, useEffect, useRef } from 'react'
+import { useErrorBoundary } from 'react-error-boundary'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   AssistantState,
@@ -7,8 +9,6 @@ import {
   setSemanticModels,
 } from '../slices/assistantSlice'
 import { RootState } from '../store'
-import { ExtensionContext } from '@looker/extension-sdk-react'
-import { useErrorBoundary } from 'react-error-boundary'
 
 export const useLookerFields = () => {
   const {
@@ -35,7 +35,7 @@ export const useLookerFields = () => {
     if (supportedExplores.length === 0 || isSemanticModelLoaded) {
       return
     }
-    
+
     // mark
     hasFetched.current = true
 
@@ -94,9 +94,10 @@ export const useLookerFields = () => {
           measures,
         }
       } catch (error) {
-        showBoundary({
-          message: `Failed to fetch semantic model for ${modelName}::${exploreId}`,
-        })
+        console.error(error)
+        // showBoundary({
+        //   message: `Failed to fetch semantic model for ${modelName}::${exploreId}`,
+        // })
         return undefined
       }
     }
@@ -106,7 +107,7 @@ export const useLookerFields = () => {
         const fetchPromises = supportedExplores.map((exploreKey) => {
           const [modelName, exploreId] = exploreKey.split(':')
           return fetchSemanticModel(modelName, exploreId, exploreKey).then(
-            (model) => ({ exploreKey, model })
+            (model) => ({ exploreKey, model }),
           )
         })
 

--- a/explore-assistant-extension/src/hooks/useLookerFields.ts
+++ b/explore-assistant-extension/src/hooks/useLookerFields.ts
@@ -7,6 +7,7 @@ import {
   SemanticModel,
   setIsSemanticModelLoaded,
   setSemanticModels,
+  setCurrenExplore,
 } from '../slices/assistantSlice'
 import { RootState } from '../store'
 
@@ -14,6 +15,7 @@ export const useLookerFields = () => {
   const {
     examples: { exploreSamples },
     isSemanticModelLoaded,
+    currentExplore,
   } = useSelector((state: RootState) => state.assistant as AssistantState)
 
   const supportedExplores = Object.keys(exploreSamples)
@@ -122,6 +124,24 @@ export const useLookerFields = () => {
 
         dispatch(setSemanticModels(semanticModels))
         dispatch(setIsSemanticModelLoaded(true))
+        
+        // Update currentExplore to the first available explore from semantic models
+        const availableExploreKeys = Object.keys(semanticModels)
+        if (availableExploreKeys.length > 0) {
+          // Check if current explore is still available
+          const currentExploreKey = currentExplore?.exploreKey
+          
+          // Only update if current explore is not available or not set
+          if (!currentExploreKey || !semanticModels[currentExploreKey]) {
+            const firstExploreKey = availableExploreKeys[0]
+            const firstSemanticModel = semanticModels[firstExploreKey]
+            dispatch(setCurrenExplore({
+              exploreKey: firstExploreKey,
+              modelName: firstSemanticModel.modelName,
+              exploreId: firstSemanticModel.exploreId,
+            }))
+          }
+        }
       } catch (error) {
         showBoundary({
           message: 'Failed to load semantic models',

--- a/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
+++ b/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
@@ -686,23 +686,27 @@ ${exploreRefinementExamples &&
       console.log("Model: ", model)
       try {
 
+        const sql =
+          'INSERT INTO ${explore_assistant_logging.SQL_TABLE_NAME (user, model, explore, question, explore_url, timestamp) VALUES (?, ?, ?, ?, ?, ?)'
+        const values = [
+          me.id!,
+          model.replaceAll('_', ' '),
+          explore.replaceAll('_', ' '),
+          JSON.stringify(question),
+          JSON.stringify(responseJSON)
+            .replaceAll('_', ' ')
+            .replaceAll('"', "'")
+            .replaceAll(',', ' '),
+          (Date.now() / 1000).toString(),
+        ]
+        const sql_query = await core40SDK.ok(
+          core40SDK.create_sql_query({
+            sql: `EXECUTE IMMEDIATE "${sql}" USING '${values.join("','")}'`,
+            model_name: modelName || 'explore_assistant',
+          }),
+        )
         core40SDK.ok(
-          core40SDK.run_inline_query({
-            result_format: 'json',
-            body: {
-              model: modelName || "explore_assistant",
-              view: "explore_assistant_logging",
-              fields:['explore_assistant_logging.col'],
-              filters: {
-                "explore_assistant_logging.user" : me.id ?? '',
-                "explore_assistant_logging.model" : model.replaceAll("_"," ") ?? '',
-                "explore_assistant_logging.explore" : explore.replaceAll("_"," ") ?? '',
-                "explore_assistant_logging.question" : JSON.stringify(question),
-                "explore_assistant_logging.explore_url" : JSON.stringify(responseJSON).replaceAll("_"," ").replaceAll('"',"'").replaceAll(","," "),
-                "explore_assistant_logging.timestamp" : (Date.now() / 1000).toString()
-              }
-            }
-          })
+          core40SDK.run_sql_query(sql_query.slug!, 'json'),
         )
 
         return responseJSON

--- a/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
+++ b/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
@@ -687,7 +687,7 @@ ${exploreRefinementExamples &&
       try {
 
         const sql =
-          'INSERT INTO ${explore_assistant_logging.SQL_TABLE_NAME (user, model, explore, question, explore_url, timestamp) VALUES (?, ?, ?, ?, ?, ?)'
+          'INSERT INTO ${explore_assistant_logging.SQL_TABLE_NAME} (user, model, explore, question, explore_url, timestamp) VALUES (?, ?, ?, ?, ?, ?)'
         const values = [
           me.id!,
           model.replaceAll('_', ' '),

--- a/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
+++ b/explore-assistant-extension/src/hooks/useSendVertexMessage.ts
@@ -690,13 +690,10 @@ ${exploreRefinementExamples &&
           'INSERT INTO ${explore_assistant_logging.SQL_TABLE_NAME} (user, model, explore, question, explore_url, timestamp) VALUES (?, ?, ?, ?, ?, ?)'
         const values = [
           me.id!,
-          model.replaceAll('_', ' '),
-          explore.replaceAll('_', ' '),
-          JSON.stringify(question),
-          JSON.stringify(responseJSON)
-            .replaceAll('_', ' ')
-            .replaceAll('"', "'")
-            .replaceAll(',', ' '),
+          model.replace(/'/g, "\\'"),
+          explore.replace(/'/g, "\\'"),
+          JSON.stringify(question).replace(/'/g, "\\'"),
+          JSON.stringify(responseJSON).replace(/'/g, "\\'"),
           (Date.now() / 1000).toString(),
         ]
         const sql_query = await core40SDK.ok(

--- a/explore-assistant-extension/src/pages/AgentPage/index.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/index.tsx
@@ -364,28 +364,37 @@ const AgentPage = () => {
               </div>
 
               <div className="flex flex-col max-w-3xl m-auto mt-16">
-                {explores.length > 1 && (
+                {explores.length > 0 ? (
+                  <>
+                    <div className="text-md border-b-2 p-2 max-w-3xl">
+                      <FormControl className="">
+                        <InputLabel>Explore</InputLabel>
+                        <Select
+                          value={currentExplore.exploreKey}
+                          label="Explore"
+                          onChange={handleExploreChange}
+                        >
+                          {explores.map((oneExplore) => (
+                            <MenuItem
+                              key={oneExplore.exploreKey}
+                              value={oneExplore.exploreKey}
+                            >
+                              {toCamelCase(oneExplore.exploreId)}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </div>
+                    <SamplePrompts />
+                  </>
+                ) : (
                   <div className="text-md border-b-2 p-2 max-w-3xl">
-                    <FormControl className="">
-                      <InputLabel>Explore</InputLabel>
-                      <Select
-                        value={currentExplore.exploreKey}
-                        label="Explore"
-                        onChange={handleExploreChange}
-                      >
-                        {explores.map((oneExplore) => (
-                          <MenuItem
-                            key={oneExplore.exploreKey}
-                            value={oneExplore.exploreKey}
-                          >
-                            {toCamelCase(oneExplore.exploreId)}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    </FormControl>
+                    <h1 className="text-2xl font-bold">No explores found</h1>
+                    <p className="text-gray-500">
+                      Please reach out to your Looker team to use the assistant.
+                    </p>
                   </div>
                 )}
-                <SamplePrompts />
               </div>
 
               <div

--- a/explore-assistant-extension/src/pages/AgentPage/index.tsx
+++ b/explore-assistant-extension/src/pages/AgentPage/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import PromptInput from './PromptInput'
 import Sidebar from './Sidebar'
 import { v4 as uuidv4 } from 'uuid'
+import { useLookerFields } from '../../hooks/useLookerFields'
 
 import './style.css'
 import SamplePrompts from '../../components/SamplePrompts'
@@ -68,12 +69,13 @@ const AgentPage = () => {
     isSemanticModelLoaded,
   } = useSelector((state: RootState) => state.assistant as AssistantState)
 
-  const explores = Object.keys(examples.exploreSamples).map((key) => {
-    const exploreParts = key.split(':')
+  // Get explores from semanticModels instead of examples.exploreSamples
+  const explores = Object.keys(semanticModels).map((exploreKey) => {
+    const semanticModel = semanticModels[exploreKey]
     return {
-      exploreKey: key,
-      modelName: exploreParts[0],
-      exploreId: exploreParts[1],
+      exploreKey: exploreKey,
+      modelName: semanticModel.modelName,
+      exploreId: semanticModel.exploreId,
     }
   })
 


### PR DESCRIPTION
If a user doesn't have access to an explore, we used to throw full-screen errors. Now, when we catch them, we print the error and display the explores they do have access to.

We are also adjusting the dropdown on the home screen to only display explores the user has access to.